### PR TITLE
add term identifiers and fetch to word2vec

### DIFF
--- a/lib/penelope/ml/word2vec/index.ex
+++ b/lib/penelope/ml/word2vec/index.ex
@@ -247,7 +247,7 @@ defmodule Penelope.ML.Word2vec.Index do
     :e2qc.cache(name, id, fn -> do_fetch(index, id) end)
   end
 
-  def do_fetch(%{header: header}, id) do
+  defp do_fetch(%{header: header}, id) do
     case :dets.lookup(header, id) do
       [{_id, term}]    -> term
       []               -> nil
@@ -266,7 +266,7 @@ defmodule Penelope.ML.Word2vec.Index do
     :e2qc.cache(name, term, fn -> do_lookup(index, term) end)
   end
 
-  def do_lookup(%{vector_size: vector_size} = index, term) do
+  defp do_lookup(%{vector_size: vector_size} = index, term) do
     bit_size = vector_size * 32
     case index
          |> get_table(term)

--- a/lib/penelope/ml/word2vec/mean_vectorizer.ex
+++ b/lib/penelope/ml/word2vec/mean_vectorizer.ex
@@ -20,8 +20,13 @@ defmodule Penelope.ML.Word2vec.MeanVectorizer do
 
   defp vectorize(x, index, vector_size) do
     x
-    |> Stream.map(&Index.lookup!(index, &1))
+    |> Stream.map(&lookup(&1, index))
     |> Enum.reduce(Vector.zeros(vector_size), &Vector.add/2)
     |> Vector.scale(1 / Enum.count(x))
+  end
+
+  defp lookup(x, index) do
+    {_id, v} = Index.lookup!(index, x)
+    v
   end
 end

--- a/test/penelope/ml/word2vec/index_test.exs
+++ b/test/penelope/ml/word2vec/index_test.exs
@@ -43,23 +43,30 @@ defmodule Penelope.ML.Word2vec.IndexTest do
     index = Index.create!(output, "test", vector_size: 10)
 
     assert_raise IndexError, fn ->
-      Index.insert!(index, Index.parse_line!("invalid 1"))
+      {term, vector} = Index.parse_line!("invalid 1")
+      Index.insert!(index, {term, 1, vector})
     end
     assert_raise IndexError, fn ->
-      Index.parse_insert!(index, "invalid 1")
+      Index.parse_insert!(index, {"invalid 1", 1})
     end
 
-    Index.insert!(index, Index.parse_line!("hello 1 2 3 4 5 6 7 8 9 10"))
-    Index.parse_insert!(index, "goodbye 10 9 8 7 6 5 4 3 2 1")
-
     Index.compile!(index, input)
+    {term, vector} = Index.parse_line!("hello 1 2 3 4 5 6 7 8 9 10")
+    Index.insert!(index, {term, 11, vector})
+    Index.parse_insert!(index, {"goodbye 10 9 8 7 6 5 4 3 2 1", 12})
+
     Index.close(index)
 
     index = Index.open!(output)
-    assert Index.lookup!(index, "invalid") == Vector.zeros(10)
-    assert Index.lookup!(index, "missing") == Vector.zeros(10)
-    assert Index.lookup!(index, "hello") == Vector.from_list(1..10)
-    assert Index.lookup!(index, "goodbye") == Vector.from_list(10..1)
+
+    assert Index.fetch!(index, 0) == nil
+    assert Index.fetch!(index, 11) == "hello"
+    assert Index.fetch!(index, 12) == "goodbye"
+
+    assert Index.lookup!(index, "invalid") == {0, Vector.zeros(10)}
+    assert Index.lookup!(index, "missing") == {0, Vector.zeros(10)}
+    assert Index.lookup!(index, "hello") == {11, Vector.from_list(1..10)}
+    assert Index.lookup!(index, "goodbye") == {12, Vector.from_list(10..1)}
 
     1..10
     |> Enum.each(fn i ->
@@ -67,7 +74,8 @@ defmodule Penelope.ML.Word2vec.IndexTest do
         vector = 1..10
                  |> Enum.map(fn j -> i / j end)
                  |> Vector.from_list()
-        assert(Index.lookup!(index, word) == vector)
+        assert Index.fetch!(index, i) == word
+        assert Index.lookup!(index, word) == {i, vector}
       end)
 
     Index.close(index)

--- a/test/penelope/ml/word2vec/mean_vectorizer_test.exs
+++ b/test/penelope/ml/word2vec/mean_vectorizer_test.exs
@@ -13,10 +13,10 @@ defmodule Penelope.ML.Word2vec.MeanVectorizerTest do
     output = "/tmp/penelope_ml_word2vec_meanvectorizertest"
 
     index = Index.create!(output, "test", vector_size: 2)
-    Index.parse_insert!(index, "the 1 1.5")
-    Index.parse_insert!(index, "fox 2 4.5")
-    Index.parse_insert!(index, "dog 5 7.5")
-    Index.parse_insert!(index, "horse 0 3")
+    Index.parse_insert!(index, {"the 1 1.5", 1})
+    Index.parse_insert!(index, {"fox 2 4.5", 2})
+    Index.parse_insert!(index, {"dog 5 7.5", 3})
+    Index.parse_insert!(index, {"horse 0 3", 4})
 
     on_exit fn ->
       Index.close(index)


### PR DESCRIPTION
These changes add unique integer ids to each term and a lookup by id to the word2vec index.