### PR TITLE
fix nif issues with hex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ erl_crash.dump
 *.iml
 
 # Private files
-/priv/penelope.so
 /obj/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt install libblas-dev
 ```elixir
 def deps do
   [
-    {:penelope, "~> 0.1.0"}
+    {:penelope, "~> 0.2.4"}
   ]
 end
 ```

--- a/lib/penelope/nif.ex
+++ b/lib/penelope/nif.ex
@@ -13,7 +13,8 @@ defmodule Penelope.NIF do
   @doc "module initialization callback"
   @spec init() :: :ok
   def init do
-    with {:error, reason} <- :erlang.load_nif('./priv/penelope', 0) do
+    path = Path.join(Application.app_dir(:penelope, "priv"), "penelope")
+    with {:error, reason} <- :erlang.load_nif(String.to_charlist(path), 0) do
       raise inspect(reason)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Penelope.Mixfile do
     [
       app:               :penelope,
       name:              "Penelope",
-      version:           "0.2.1",
+      version:           "0.2.4",
       elixir:            "~> 1.5",
       compilers:         ["nif" | Mix.compilers],
       aliases:           [clean: ["clean", "clean.nif"]],
@@ -54,7 +54,7 @@ defmodule Penelope.Mixfile do
 
   defp package do
   [
-    files:       ["mix.exs", "README.md", "lib", "c_src"],
+    files:       ["mix.exs", "README.md", "lib", "c_src", "priv/.gitignore"],
     maintainers: ["Brent M. Spell", "Josh Ziegler"],
     licenses:    ["Apache 2.0"],
     links:       %{"GitHub" => "https://github.com/pylon/penelope",

--- a/priv/.gitignore
+++ b/priv/.gitignore
@@ -1,0 +1,1 @@
+penelope.so


### PR DESCRIPTION
These changes fix a path problem to the penelope nif, which was previously looking in the root directory, which was a problem when loaded as a library.

Another problem was that the priv directory was not being propagated to the dependent project's release directory because it was not included in the hex configuration for this project. Putting the priv directory in the hex config is problematic because it can cause the platform-specific build target to be pushed to hex (a common mistake). Instead, these changes just add the .gitignore file in priv, which forces the dependent project to include the priv directory.