### PR TITLE
allow multiple active word2vec indices

### DIFF
--- a/lib/penelope/ml/word2vec/index.ex
+++ b/lib/penelope/ml/word2vec/index.ex
@@ -83,7 +83,9 @@ defmodule Penelope.ML.Word2vec.Index do
 
     options = [file: file, access: :read_write, type: :set, min_no_slots: 1]
 
-    with {:ok, file} <- :dets.open_file(:word2vec_header, options),
+    name = String.to_atom(path)
+
+    with {:ok, file} <- :dets.open_file(name, options),
          :ok <- :dets.insert(file, {:header, header}) do
       file
     else
@@ -173,7 +175,9 @@ defmodule Penelope.ML.Word2vec.Index do
 
     options = [file: file, access: :read, type: :set]
 
-    with {:ok, file} <- :dets.open_file(:word2vec_header, options),
+    name = String.to_atom(path)
+
+    with {:ok, file} <- :dets.open_file(name, options),
          [{:header, header}] <- :dets.lookup(file, :header) do
       {file, header}
     else

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Penelope.Mixfile do
     [
       app: :penelope,
       name: "Penelope",
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.6",
       compilers: ["nif" | Mix.compilers()],
       aliases: [clean: ["clean", "clean.nif"]],
@@ -59,7 +59,13 @@ defmodule Penelope.Mixfile do
 
   defp package do
     [
-      files: ["mix.exs", "README.md", "lib", "c_src", "priv/.gitignore"],
+      files: [
+        "mix.exs",
+        "README.md",
+        "lib",
+        "c_src/**/{*.c,*.cpp,*.h,*.hpp,Makefile,*.makefile}",
+        "priv/.gitignore"
+      ],
       maintainers: ["Brent M. Spell", "Josh Ziegler"],
       licenses: ["Apache 2.0"],
       links: %{


### PR DESCRIPTION
These changes generate new dets table ids for the index headers, based on the file path. Also included is a more specific glob for source files, since hex now limits tarballs to 8MB.